### PR TITLE
adds required authors prompt

### DIFF
--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -3,6 +3,7 @@ name = "{{ cookiecutter.distribution_name }}"
 version = "{{ cookiecutter.version }}"
 description = "{{ cookiecutter.description }}"
 license = "{{ cookiecutter.license }}"
+authors = "{{ cookiecutter.authors }}"
 readme = "{{ cookiecutter.readme }}"
 keywords = [{{ cookiecutter.keywords }}]
 


### PR DESCRIPTION
I tested making a new plugin with this! Minor feedback, it looks like the [`authors`](https://github.com/sdispater/poetry#authors) field is required. We could get really fancy and use a user's git config settings, but this will probably be fine for now.

This hopefully relieves the following message:

```
> poetry install
                                   
[NonExistentKey]    
'Key "authors" does not exist.'  
```

Using this version of Poetry:

```
> poetry --version
Poetry 0.12.17
```