### PR TITLE
WIP: Use Pelican Git repo for local development

### DIFF
--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -48,6 +48,7 @@ pelican = "{{ cookiecutter.pelican_version }}"
 markdown = {version = "^3.1.1",optional = true}
 
 [tool.poetry.dev-dependencies]
+pelican = { git = "https://github.com/getpelican/pelican.git" }
 black = {version = "^19.10b0",allows-prereleases = true}
 flake8 = "^3.7"
 flake8-black = "^0.1.0"

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -48,7 +48,6 @@ pelican = "{{ cookiecutter.pelican_version }}"
 markdown = {version = "^3.1.1",optional = true}
 
 [tool.poetry.dev-dependencies]
-pelican = { git = "https://github.com/getpelican/pelican.git" }
 black = {version = "^19.10b0",allows-prereleases = true}
 flake8 = "^3.7"
 flake8-black = "^0.1.0"

--- a/{{cookiecutter.repo_name}}/tasks.py
+++ b/{{cookiecutter.repo_name}}/tasks.py
@@ -73,5 +73,8 @@ def precommit(c):
 def setup(c):
     c.run(f"{VENV}/bin/pip install -U pip")
     tools(c)
-    c.run(f"{POETRY} install --develop pelican")
+    c.run(
+        f"{POETRY} run pip install -e git://github.com/getpelican/pelican.git#egg=pelican"
+    )
+    c.run(f"{POETRY} install")
     precommit(c)

--- a/{{cookiecutter.repo_name}}/tasks.py
+++ b/{{cookiecutter.repo_name}}/tasks.py
@@ -73,5 +73,5 @@ def precommit(c):
 def setup(c):
     c.run(f"{VENV}/bin/pip install -U pip")
     tools(c)
-    c.run(f"{POETRY} install")
+    c.run(f"{POETRY} install --develop pelican")
     precommit(c)


### PR DESCRIPTION
It will fix: #3 (hopefully)

- [This issue](https://github.com/sdispater/poetry/issues/1168) reflects what we'd require in order to have a different Pelican version for development.
- [Poetry 1.0 will remove the `--develop` option](https://github.com/sdispater/poetry/releases/tag/1.0.0b1), and it only applied to paths anyway.