### PR TITLE
Let Poetry maintain license and Python version classifiers

### DIFF
--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -18,21 +18,7 @@ classifiers = [
     "Framework :: Pelican",
     "Framework :: Pelican :: Plugins",
     "Intended Audience :: End Users/Desktop",
-{%- if cookiecutter.license == "AGPL-3.0" %}
-    "License :: OSI Approved :: GNU Affero General Public License v3",
-{%- elif cookiecutter.license == "Apache-2.0" %}
-    "License :: OSI Approved :: Apache Software License",
-{%- elif cookiecutter.license in ["BSD-2-Clause", "BSD-3-Clause"] %}
-    "License :: OSI Approved :: BSD License",
-{%- elif cookiecutter.license == "MIT" %}
-    "License :: OSI Approved :: MIT License",
-{%- endif %}
     "Operating System :: OS Independent",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]


### PR DESCRIPTION
I carefully tested that on my own packages. I'd like to point to Poetry code but can't managed to find it out! 😅