### PR TITLE
Tweak some README.md structure

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.readme}}
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.readme}}
@@ -1,4 +1,5 @@
-# {{ cookiecutter.plugin_name }}: A Plugin for Pelican
+{{ cookiecutter.plugin_name }}: A Plugin for Pelican
+====================================================
 
 [![Build Status](https://img.shields.io/github/workflow/status/pelican-plugins/{{ cookiecutter.repo_name }}/build)]({{ cookiecutter.repo_url }}/actions)
 [![PyPI Version](https://img.shields.io/pypi/v/{{ cookiecutter.distribution_name }})](https://pypi.org/project/{{ cookiecutter.distribution_name }}/)
@@ -12,6 +13,11 @@ Installation
 This plugin can be installed via:
 
     python -m pip install {{ cookiecutter.distribution_name }}
+
+Usage
+-----
+
+<<Add plugin details here>>
 
 Contributing
 ------------


### PR DESCRIPTION
* Use sharp-leading subtitles (no need to maintain the underline at length)
* Use a period to end description (description from cookiecutter template is dot-less)
* Invite user to fill in the blank of the `README` with usage example and previous plugin `README`