### PR TITLE
Aligns minimal version to Pelican's

### DIFF
--- a/{{cookiecutter.repo_name}}/.github/workflows/main.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.6
       - name: Set Poetry cache
         uses: actions/cache@v2
         id: poetry-cache
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.6
       - name: Check release
         id: check_release
         run: |

--- a/{{cookiecutter.repo_name}}/.github/workflows/main.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Set Poetry cache
         uses: actions/cache@v2
         id: poetry-cache
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Check release
         id: check_release
         run: |

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     hooks:
       - id: flake8
         args: [--max-line-length=88]
-        language_version: python3.7
+        language_version: python3.6
 
   - repo: https://github.com/timothycrosley/isort
     rev: 5.4.2

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     hooks:
       - id: flake8
         args: [--max-line-length=88]
-        language_version: python3.6
+        language_version: python3.7
 
   - repo: https://github.com/timothycrosley/isort
     rev: 5.4.2


### PR DESCRIPTION
This PR sets the minimal Python version for Pelican plugins from 3.7 to 3.6, as:

* Python 3.6 is [not EOL yet](https://en.wikipedia.org/wiki/History_of_Python#Table_of_versions)
* [Pelican's advertised minimal requirement is Python 3.6](https://github.com/getpelican/pelican/blob/4.5.0/pyproject.toml#L34), so it's good for its plugins to support 3.6 by default
* [This cookiecutter template supports Python 3.6](https://github.com/getpelican/cookiecutter-pelican-plugin/blob/7af461da6c077b629cc2134a6df93c810f75f5b4/cookiecutter.json#L15)
