### PR TITLE
Fix escaping of YAML interpolation

### DIFF
--- a/{{cookiecutter.repo_name}}/.github/workflows/main.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/main.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   test:
-    name: Test - ${{ matrix.python-version }}
+    name: Test - ${{ "{{" }} matrix.python-version {{ "}}" }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Double curly braces are over-interpreted by cookie cutter as template variable. We need double escaping that else we get that error:

```
Unable to create file '.github/workflows/main.yml'
Error message: 'matrix' is undefined
```