### PR TITLE
Fix matrix is undefined error.

### DIFF
--- a/{{cookiecutter.repo_name}}/.github/workflows/main.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/main.yml
@@ -39,8 +39,8 @@ jobs:
           key: poetry-${{ "{{" }} hashFiles('**/poetry.lock') {{ "}}" }}
 
       - name: Install dependencies
-        run: |
-          poetry env use "${{ matrix.python-version }}"
+        run:
+          poetry env use "${{ "{{" }} matrix.python-version {{ "}}" }}"
           poetry install --no-interaction
 
       - name: Run tests


### PR DESCRIPTION
Small fix for a `matrix is undefined` error received when generating a project.

- Double escape curly braces.