### PR TITLE
Update PDM GitHub Actions to resolve Node.js deprecations

### DIFF
--- a/{{cookiecutter.repo_name}}/.github/workflows/main.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ "{{" }} matrix.python-version {{ "}}" }} & PDM
-        uses: pdm-project/setup-pdm@v3
+        uses: pdm-project/setup-pdm@v4
         with:
           python-version: ${{ "{{" }} matrix.python-version {{ "}}" }}
           cache: true
@@ -43,7 +43,7 @@ jobs:
           linksToSkip: "https://pypi.org/project/{{ cookiecutter.distribution_name }}/"
 
       - name: Set up Python & PDM
-        uses: pdm-project/setup-pdm@v3
+        uses: pdm-project/setup-pdm@v4
         with:
           python-version: "3.10"
           cache: true


### PR DESCRIPTION
The only important change is that Node 20 is used, so the deprecation warnings are resolved.
See https://github.com/pdm-project/setup-pdm/releases/tag/v4